### PR TITLE
1.20.3-1.20.4 compatibility

### DIFF
--- a/data/plushpets.1/functions/api/plush_pet_loot/village_house/villager.mcfunction
+++ b/data/plushpets.1/functions/api/plush_pet_loot/village_house/villager.mcfunction
@@ -1,0 +1,4 @@
+# runs if this core datapack is the newest version
+
+#run if load status matches this core datapacks version
+execute unless score #plushpets.option.no_plush_loot sourcecraft.data matches 1 if score #plushpets load.status matches 1 run function plushpets.1:plush_pet_loot/village_house/villager

--- a/data/sourcecraft.3/tags/blocks/passable.json
+++ b/data/sourcecraft.3/tags/blocks/passable.json
@@ -38,7 +38,7 @@
 		"minecraft:dead_tube_coral_fan",
 		"minecraft:dead_tube_coral_wall_fan",
 		"minecraft:fern",
-		"minecraft:grass",
+		"minecraft:short_grass",
 		"minecraft:kelp",
 		"minecraft:kelp_plant",
 		"minecraft:large_fern",


### PR DESCRIPTION
- Modified the reference from `minecraft:grass` to `minecraft:short_grass` in the block passable tag. This change accounts for the update [1.20.3-pre1](https://misode.github.io/versions/?id=1.20.3-pre1).
- Re-added the `village_house/villager.mcfunction` file. It was previously removed, but it's unclear whether this was intentional or accidental as there were still references to it in the code.